### PR TITLE
add ability to specify generated font types

### DIFF
--- a/bin/icon-font-generator
+++ b/bin/icon-font-generator
@@ -18,6 +18,7 @@ function init() {
             outputDir          : args.o || args.out,
             fontName           : args.n || args.name,
             fontsPath          : args.f || args.fontspath,
+            types              : (args.types || 'svg,ttf,woff,eot').split(','),
             css                : args.c || args.css,
             cssPath            : args.csspath,
             cssTemplate        : args.csstp,
@@ -95,6 +96,7 @@ function showHelp() {
         '  -s, --silent     '.bold + 'Do not produce output logs other than errors (Default: false)\n' +
         '  -f, --fontspath  '.bold + 'Relative path to fonts directory to use in output files (Default: ./)\n' +
         '  -c, --css        '.bold + 'Generate CSS file if true (Default: true)\n' +
+        '  --types          '.bold + 'Comma delimited list of font types (Defaults to svg,ttf,woff,eot)\n' +
         '  --csspath        '.bold + 'CSS output path (Defaults to <out>/<name>.css)\n' +
         '  --csstp          '.bold + 'CSS handlebars template path (Optional)\n' +
         '  --html           '.bold + 'Generate HTML preview file if true (Default: true)\n' +

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,6 +42,7 @@ exports.generate = function (options, callback) {
     options.json = typeof options.json === 'undefined' ? true : options.json;
     options.html = typeof options.html === 'undefined' ? true : options.html;
     options.silent = typeof options.silent === 'undefined' ? true : options.silent;
+    options.types = options.types ? options.types : FONT_TYPES;
 
     // Log start
     log(options, ('Generating font kit from ' + options.paths.length + ' SVG icons').yellow);
@@ -62,7 +63,7 @@ exports.generate = function (options, callback) {
                 files              : options.paths,
                 dest               : options.outputDir,
                 cssFontsUrl        : options.fontsPath,
-                types              : FONT_TYPES,
+                types              : options.types,
                 cssDest            : options.cssPath,
                 htmlDest           : options.htmlPath,
                 cssTemplate        : options.cssTemplate || TEMPLATES.css,
@@ -90,7 +91,7 @@ exports.generate = function (options, callback) {
             if (err) { return callback(err); }
 
             // Log font files output
-            FONT_TYPES.map(function (ext) {
+            options.types.map(function (ext) {
                 logOutput(options, [ options.outputDir, options.fontName + '.' + ext ]);
             });
 


### PR DESCRIPTION
Sometimes not all formats are needed or wanted - my project only uses woff, and the other formats shouldn't be generated or loaded at all. This PR gives the ability to pass a 'types' argument like svg,woff to generate only those formats. 
