### PR TITLE
Windows support for wildcards

### DIFF
--- a/bin/icon-font-generator
+++ b/bin/icon-font-generator
@@ -13,7 +13,10 @@ var fontGenerator = require('../lib/index'),
  */
 function init() {
     var args = minimist(process.argv.slice(2)),
-        options = {
+    if(args._.length == 1 && args._[0].indexOf('*') !== false) {
+        args._ = glob.sync(args._[0]);
+    }
+    var options = {
             paths              : args._ || [],
             outputDir          : args.o || args.out,
             fontName           : args.n || args.name,

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "colors": "^1.1.2",
     "minimist": "^1.2.0",
-    "webfonts-generator": "^0.3.3"
+    "webfonts-generator": "^0.3.3",
+    "glob": "^7.1.1"
   }
 }


### PR DESCRIPTION
Passing a single wildcard path doesn't work on Windows, this fixes the issue (for me).
It might also be a good idea to check the OS.