### PR TITLE
Make json parse work for windows environments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ const path = require('path')
 const fontGenerator = require('webfonts-generator')
 const async = require('async')
 
-const CSS_PARSE_REGEX = /\-(.*)\:before.*\n\s*content: "(.*)"/gm
+const CSS_PARSE_REGEX = /\-(.*)\:before.*\r?\n\s*content: "(.*)"/gm
 const FONT_TYPES = [ 'svg', 'ttf', 'woff', 'woff2', 'eot' ]
 const TEMPLATES = {
   html : path.resolve(__dirname, '../template/html.hbs'),


### PR DESCRIPTION
Currently the regex doesn't match on windows environments due to the CRLF. This minor fix does make the regex work on windows enviroments as well.