### PR TITLE
Fix invalid default prefix value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ function generate(options, callback) {
       htmlTemplate    : options.htmlTemplate || TEMPLATES.html,
       templateOptions : {
         baseTag     : options.baseTag || 'i',
-        classPrefix : (options.classPrefix || 'icons') + '-'
+        classPrefix : (options.classPrefix || 'icon') + '-'
       }
     }
 


### PR DESCRIPTION
Default CSS classname prefix value is 'icon'