### PR TITLE
Add options for code points.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Options:
   --htmlpath       HTML output path (Defaults to <out>/<name>.html)
   --types          Font types - (Defaults to 'svg, ttf, woff, woff2, eot')
   --htmltp         HTML handlebars template path (Optional)
+  --codepoint      The starting character code (Optional)
+  --codepoints     Path to character code JSON map file (Optional)
   -j, --json       Generate JSON map file if true (Default: true)
   --jsonpath       JSON output path (Defaults to <out>/<name>.json)
   -p, --prefix     CSS classname prefix for icons (Default: icon)

--- a/bin/icon-font-generator
+++ b/bin/icon-font-generator
@@ -32,6 +32,8 @@ function init() {
     htmlPath           : args.htmlpath,
     htmlTemplate       : args.htmltp,
     silent             : args.s || args.silent || false,
+    startCodepoint     : args.codepoint,
+    codepoints         : args.codepoints,
     classPrefix        : args.p || args.prefix,
     baseTag            : args.t || args.tag,
     normalize          : args.normalize,
@@ -103,6 +105,8 @@ function showHelp() {
     '  --html           '.bold + 'Generate HTML preview file if true (Default: true)\n' +
     '  --htmlpath       '.bold + 'HTML output path (Defaults to <out>/<name>.html)\n' +
     '  --htmltp         '.bold + 'HTML handlebars template path (Optional)\n' +
+    '  --codepoint      '.bold + 'The starting character code to count up from (Optional)\n' +
+    '  --codepoints     '.bold + 'Path to explicit character code mapping JSON file (Optional)\n' + 
     '  -j, --json       '.bold + 'Generate JSON map file if true (Default: true)\n' +
     '  --jsonpath       '.bold + 'JSON output path (Defaults to <out>/<name>.json)\n' +
     '  -p, --prefix     '.bold + 'CSS classname prefix for icons (Default: icon)\n' +

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,11 +65,19 @@ function generate(options, callback) {
   validate(options, err => {
     if (err) { return callback(err) }
 
+    let codepoints = {}
+    if (options.codepoints) {
+      codepoints = fs.readFileSync(path.resolve(options.codepoints))
+      codepoints = JSON.parse(codepoints)
+    }
+    
     let config = {
       files           : options.paths,
       dest            : options.outputDir,
       cssFontsUrl     : options.fontsPath,
       types           : options.types,
+      codepoints      : codepoints,
+      startCodepoint  : options.startCodepoint || 0xF101,
       cssDest         : options.cssPath,
       htmlDest        : options.htmlPath,
       cssTemplate     : options.cssTemplate  || TEMPLATES.css,
@@ -77,7 +85,7 @@ function generate(options, callback) {
       templateOptions : {
         baseTag     : options.baseTag || 'i',
         classPrefix : (options.classPrefix || 'icons') + '-'
-      }
+      },
     }
 
     // Add available options to generator config

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,9 +7,14 @@ const fs = require('fs')
 const path = require('path')
 const fontGenerator = require('webfonts-generator')
 const async = require('async')
-const util = require('util')
 
-const CSS_PARSE_REGEX = /\-(.*)\:before.*\n\s*content: "(.*)"/gm
+/**
+ * Windows or Mac style line endings shouldn't be a problem.
+ * However, I was unable to parse the CSS without adding a carriage return.
+ * To avoid conflicting with a build on a Linux system I added a check to make sure we're on Mac or Windows.
+ */ 
+const IS_WIN_OR_MAC = (process.platform == "win32" || process.platform == "darwin")
+const CSS_PARSE_REGEX = IS_WIN_OR_MAC ? /\-(.*)\:before.*\r\n\s*content: "(.*)"/gm : /\-(.*)\:before.*\n\s*content: "(.*)"/gm
 const FONT_TYPES = [ 'svg', 'ttf', 'woff', 'woff2', 'eot' ]
 const TEMPLATES = {
   html : path.resolve(__dirname, '../template/html.hbs'),

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ const fs = require('fs')
 const path = require('path')
 const fontGenerator = require('webfonts-generator')
 const async = require('async')
+const util = require('util')
 
 const CSS_PARSE_REGEX = /\-(.*)\:before.*\n\s*content: "(.*)"/gm
 const FONT_TYPES = [ 'svg', 'ttf', 'woff', 'woff2', 'eot' ]
@@ -66,8 +67,9 @@ function generate(options, callback) {
     if (err) { return callback(err) }
 
     let codepoints = {}
-    let codepointsPath = path.resolve(options.codepoints)
+    let tempCodepoints = {}
     if (options.codepoints) {
+      let codepointsPath = path.resolve(options.codepoints)
       fs.exists(codepointsPath, exists => {
         if (!exists) {
           let msg = `Cannot find json file @ ${options.codepoints}!`
@@ -80,7 +82,11 @@ function generate(options, callback) {
           }
         })
       })
-      codepoints = JSON.parse(fs.readFileSync(path.resolve(options.codepoints)))
+      tempCodepoints = JSON.parse(fs.readFileSync(path.resolve(options.codepoints)))
+      
+      for (let propName in tempCodepoints) {
+        codepoints[propName] = Number.parseInt(tempCodepoints[propName])
+      }
     }
 
     let config = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,11 +66,23 @@ function generate(options, callback) {
     if (err) { return callback(err) }
 
     let codepoints = {}
+    let codepointsPath = path.resolve(options.codepoints)
     if (options.codepoints) {
-      codepoints = fs.readFileSync(path.resolve(options.codepoints))
-      codepoints = JSON.parse(codepoints)
+      fs.exists(codepointsPath, exists => {
+        if (!exists) {
+          let msg = `Cannot find json file @ ${options.codepoints}!`
+          return callback(new error.ValidationError(msg))
+        }
+        fs.stat(codepointsPath, (err, stats) => {
+          if (!stats.isFile() || path.extname(codepointsPath) !== '.json') {
+            let msg = `Not a valid json file for mapping codepoints! ${options.codepoints} is not a valid file.`
+            return callback(new error.ValidationError(msg))
+          }
+        })
+      })
+      codepoints = JSON.parse(fs.readFileSync(path.resolve(options.codepoints)))
     }
-    
+
     let config = {
       files           : options.paths,
       dest            : options.outputDir,
@@ -85,7 +97,7 @@ function generate(options, callback) {
       templateOptions : {
         baseTag     : options.baseTag || 'i',
         classPrefix : (options.classPrefix || 'icons') + '-'
-      },
+      }
     }
 
     // Add available options to generator config


### PR DESCRIPTION
Re: #18 this patch adds options to pass over the starting code point. Also allows user to pass a path to a JSON file containing custom code points. Note that all input code points should be in the form 0xf101 instead of \f101. I didn't add any escaped code to character integer parsing. Still it works well enough and I doubt many folks will find use for the JSON part. If they do, I imagine they'll be willing to work a little bit to get it working. Please let me know if any changes will be needed.