### PR TITLE
Set font-family for only i elements with classPrefix.

### DIFF
--- a/template/css.hbs
+++ b/template/css.hbs
@@ -7,11 +7,15 @@
     line-height: 1;
 }
 
-{{ baseTag }}:before {
-    font-family: {{fontName}} !important;
+{{ baseTag }}[class^="{{classPrefix}}"]:before, {{ baseTag }}[class*=" {{classPrefix}}"]:before {
+    font-family: {{ fontName }} !important;
     font-style: normal;
     font-weight: normal !important;
-    vertical-align: top;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 {{# each codepoints }}


### PR DESCRIPTION
Otherwise it overlaps with other fonts like font-awesome.
Also added some properties like font-smoothing and font-variant that added during generating font on icomoon.io