### PR TITLE
Validate paths of each format

### DIFF
--- a/bin/icon-font-generator
+++ b/bin/icon-font-generator
@@ -5,6 +5,7 @@
 require('colors')
 
 const { removeUndefinedKeys } = require('../lib/utils')
+const { FORMATS } = require('../lib/constants')
 const fontGenerator = require('../lib/index')
 const errors = require('../lib/errors')
 const minimist = require('minimist')
@@ -51,10 +52,9 @@ function init() {
   })
 
   const calledEmpty = Object.keys(args).length === 1 && args._.length === 0
-  const formats = [ 'html', 'css', 'json' ]
 
   // Parse Boolean values that default to true
-  formats.forEach(key => {
+  FORMATS.forEach(key => {
     if (typeof options[key] !== 'undefined') {
       options[key] = options[key] === 'true'
     }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -33,10 +33,17 @@ const DEFAULT_OPTIONS = {
   templateOptions : {}
 }
 
+const FORMATS = [
+  'html',
+  'css',
+  'json'
+]
+
 module.exports = {
   CSS_PARSE_REGEX,
   FONT_TYPES,
   TEMPLATES,
   OPTIONAL_PARAMS,
-  DEFAULT_OPTIONS
+  DEFAULT_OPTIONS,
+  FORMATS
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ const fs = require('fs')
 const path = require('path')
 const fontGenerator = promisify(require('webfonts-generator'))
 const {
-  CSS_PARSE_REGEX, FONT_TYPES, TEMPLATES, OPTIONAL_PARAMS, DEFAULT_OPTIONS
+  CSS_PARSE_REGEX, FONT_TYPES, TEMPLATES, OPTIONAL_PARAMS, DEFAULT_OPTIONS, FORMATS
 } = require('./constants')
 const { ValidationError } = require('./errors')
 const { log, logOutput } = require('./utils')
@@ -290,6 +290,16 @@ async function validateOptions(options) {
   if (options.htmlTemplate && !await fsAsync.exists(options.htmlTemplate)) {
     throw new ValidationError('HTML template not found')
   }
+
+  // Validate each format paths (If set)
+  FORMATS.forEach(key => {
+    const explicitPathKey = `${ key }Path`
+    if (options[explicitPathKey] === '') {
+      throw new ValidationError(`${key}path must not be blank`)
+    } else if (options[explicitPathKey] && typeof options[explicitPathKey] !== 'string') {
+      throw new ValidationError(`${key}path must be string and not be blank`)
+    }
+  })
 
   // Validate codepoints file if passed
   if (options.codepoints) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icon-font-generator",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Easy-to-use, pre-configured cli tool to generate webfont icon kits from a bunch of .svg files",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
It should throw an error when the path options specified with no value.
By this fixation, the array of formats appears twice so I moved it to `constant.js`.