### PR TITLE
Add Override font creation time parameter

### DIFF
--- a/bin/icon-font-generator
+++ b/bin/icon-font-generator
@@ -47,7 +47,8 @@ function init() {
     descent            : args.descent,
     fixedWidth         : args.mono,
     fontHeight         : args.height,
-    centerHorizontally : args.center
+    centerHorizontally : args.center,
+    timestamp          : args.timestamp
   })
 
   const calledEmpty = Object.keys(args).length === 1 && args._.length === 0
@@ -129,7 +130,8 @@ function showHelp() {
     '  --descent        '.bold + 'Offset applied to the baseline (Default: 0)\n' +
     '  --mono           '.bold + 'Make font monospace (Default: false)\n' +
     '  --height         '.bold + 'Fixed font height value\n' +
-    '  --center         '.bold + 'Center font horizontally'
+    '  --center         '.bold + 'Center font horizontally\n' +
+    '  --timestamp      '.bold + 'Override font creation time (Unix time stamp)'
   )
 }
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -20,7 +20,8 @@ const OPTIONAL_PARAMS = [
   'fontHeight',
   'descent',
   'fontHeight',
-  'centerHorizontally'
+  'centerHorizontally',
+  'timestamp'
 ]
 
 const DEFAULT_OPTIONS = {
@@ -30,7 +31,8 @@ const DEFAULT_OPTIONS = {
   html            : true,
   silent          : true,
   types           : FONT_TYPES,
-  templateOptions : {}
+  templateOptions : {},
+  formatOptions   : {}
 }
 
 module.exports = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,6 +84,11 @@ function getGeneratorConfig(options) {
         path.dirname(getResolvedPath(options, 'html')),
         getResolvedPath(options, 'css')
       )
+    },
+    formatOptions   : {
+      ttf: {
+        ts: options.timestamp
+      }
     }
   }
 


### PR DESCRIPTION
See: #60 

https://github.com/sunflowerdeath/webfonts-generator/blob/ed306cdf885a0e86c2e652de0419b284f55febc5/README.md#formatoptions

Add the ability to define the timestamp of the generated ttf font file. Useful for reproducible build.
