### PR TITLE
Additional output formats C# and Xamarin

### DIFF
--- a/bin/icon-font-generator
+++ b/bin/icon-font-generator
@@ -36,6 +36,14 @@ function init() {
     html               : args.html,
     htmlPath           : args.htmlpath,
     htmlTemplate       : args.htmltp,
+	cs                 : args.cs,
+	csPath             : args.cspath,
+	csName             : args.csname,
+	csNamespace        : args.csnamespace,
+	csPrefix           : args.csprefix,
+	xamarin            : args.xamarin,
+	xamarinPath        : args.xamarinpath,
+	xamarinPrefix      : args.xamarinprefix,
     silent             : args.s || args.silent || false,
     startCodepoint     : args.codepoint,
     codepoints         : args.codepoints,
@@ -51,7 +59,7 @@ function init() {
   })
 
   const calledEmpty = Object.keys(args).length === 1 && args._.length === 0
-  const formats = [ 'html', 'css', 'json' ]
+  const formats = [ 'html', 'css', 'json', 'cs', 'xamarin' ]
 
   // Parse Boolean values that default to true
   formats.forEach(key => {
@@ -117,6 +125,14 @@ function showHelp() {
     '  --html           '.bold + 'Generate HTML preview file if true (Default: true)\n' +
     '  --htmlpath       '.bold + 'HTML output path (Defaults to <out>/<name>.html)\n' +
     '  --htmltp         '.bold + 'HTML handlebars template path (Optional)\n' +
+	'  --cs             '.bold + 'Generate CS file if true (Default: true)\n' +
+	'  --cspath         '.bold + 'CS output path (Defaults to <out>/<name>.cs)\n' +
+	'  --csname         '.bold + 'CS class name (Defaults to IconFontConstants)\n' +
+	'  --csnamespace    '.bold + 'CS namespace (Defaults to System)\n' +
+	'  --csprefix       '.bold + 'Prefix for CS class members (Defaults to Icon_)\n' +
+	'  --xamarin        '.bold + 'Generate Xamarin ResourceDictionary (*.xaml) if true (Default: true)\n' +
+	'  --xamarinpath    '.bold + 'Xamarin ResourceDictionary output path (Defaults to <out>/<name>.xaml)\n' +
+	'  --xamarinprefix  '.bold + 'Prefix for Xamarin ResourceDictionary entries (Defaults to Icon_)\n' +
     '  --codepoint      '.bold + 'The starting character code to count up from (Optional)\n' +
     '  --codepoints     '.bold + 'Path to explicit character code mapping JSON file (Optional)\n' +
     '  -j, --json       '.bold + 'Generate JSON map file if true (Default: true)\n' +

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -28,6 +28,12 @@ const DEFAULT_OPTIONS = {
   css             : true,
   json            : true,
   html            : true,
+  cs              : true,
+  csName          : 'IconFontConstants',
+  csNamespace     : 'System',
+  csPrefix        : 'Icon_',
+  xamarin         : true,
+  xamarinPrefix   : 'Icon_',
   silent          : true,
   types           : FONT_TYPES,
   templateOptions : {}

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,6 +51,16 @@ async function generate(options = {}) {
   if (options.json) {
     await generateJson(options, generatorResult)
   }
+  
+  // If specified, generate CS map
+  if (options.cs) {
+    await generateCs(options, generatorResult)
+  }
+  
+  // If specified, generate Xamarin ResourceDictionary
+  if (options.xamarin) {
+    await generateXamarinResourceDictionary(options, generatorResult)
+  }
 
   // Log generated files
   logReport(options)
@@ -170,8 +180,8 @@ async function getCodepointsMap(filepath) {
  * @param  {?String} type
  * @return {void}
  */
-function getResolvedPath(options, type = 'html') {
-  const explicitPathKey = `${ type }Path`
+function getResolvedPath(options, type = 'html', keyName = undefined) {
+  const explicitPathKey = `${ keyName || type }Path`
 
   if (options[explicitPathKey]) {
     return path.resolve(options[explicitPathKey])
@@ -206,6 +216,16 @@ function logReport(options) {
   if (options.json) {
     logOutput(options, [ getResolvedPath(options, 'json') ])
   }
+  
+  // Log CS map output
+  if (options.cs) {
+    logOutput(options, [ getResolvedPath(options, 'cs') ])
+  }
+  
+  // Log Xamarin ResourceDictionary output
+  if (options.xamarin) {
+    logOutput(options, [ getResolvedPath(options, 'xaml', 'xamarin') ])
+  }
 
   // Log final message
   log(options, 'Done'.green)
@@ -229,6 +249,58 @@ async function generateJson(options, generatorResult) {
   css.replace(CSS_PARSE_REGEX, (match, name, code) => map[name] = code)
 
   await fsAsync.writeFile(jsonPath, JSON.stringify(map, null, 4))
+}
+
+/**
+ * Generate CS icons map by parsing the generated CSS
+ *
+ * @param  {Object} options
+ * @param  {Object} generatorResult
+ * @return {void}
+ */
+async function generateCs(options, generatorResult) {
+  const csPath = getResolvedPath(options, 'cs');
+
+  const css = generatorResult.generateCss()
+  let map = {}
+
+  css.replace(CSS_PARSE_REGEX, (match, name, code) => map[name] = code)
+
+  var file = fs.createWriteStream(csPath)
+  file.write(`namespace ${options.csNamespace}\n`)
+  file.write('{\n')
+  file.write(`    public static class ${options.csName}\n`)
+  file.write('    {\n')
+  for (const [key, value] of Object.entries(map)) {
+    file.write(`        public const string ${options.csPrefix}${key} = "${value.replace('\\', '\\u')}";\n`)
+  }
+  file.write('    }\n')
+  file.write('}\n')
+  file.end()
+}
+
+/**
+ * Generate Xamarin ResourceDictionary by parsing the generated CSS
+ *
+ * @param  {Object} options
+ * @param  {Object} generatorResult
+ * @return {void}
+ */
+async function generateXamarinResourceDictionary(options, generatorResult) {
+  const xamlPath = getResolvedPath(options, 'xaml', 'xamarin');
+
+  const css = generatorResult.generateCss()
+  let map = {}
+
+  css.replace(CSS_PARSE_REGEX, (match, name, code) => map[name] = code)
+
+  var file = fs.createWriteStream(xamlPath)
+  file.write('<ResourceDictionary xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">\n')
+  for (const [key, value] of Object.entries(map)) {
+    file.write(`    <x:String x:Key="${options.xamarinPrefix}${key}">${value.replace('\\', '&#x')};</x:String>\n`)
+  }
+  file.write('</ResourceDictionary>')
+  file.end()
 }
 
 /**


### PR DESCRIPTION
Xamarin 4 has improved support for icon fonts, which makes dealing with scalable icons in Xamarin much easier.

I modified icon-font-generator to generate two additional outputs:

- A C# class containing the unicode constants
- A Xamarin ResourceDictionary containing the unicode constants

icon-font-generator is a really helpful tool, and it would be nice if it supported these additional output formats out of the box.