### PR TITLE
Improve code point parsing

### DIFF
--- a/lib/codepoint.js
+++ b/lib/codepoint.js
@@ -1,0 +1,19 @@
+const { ValidationError } = require('./errors')
+
+function isNumber(value) {
+  return value.match(/^((0x[\d[a-f]+)|(\d+))$/gi)
+}
+
+function parseCodePoint(codePoint, propName) {
+  if(isNumber(codePoint)) {
+    return Number.parseInt(codePoint)
+  }
+  else if(codePoint.length === 1) {
+    return codePoint.charCodeAt(0)
+  }
+  else {
+    throw new ValidationError('Codepoints map contains invalid code point for icon \'' + propName + '\'')
+  }
+}
+
+module.exports = { parseCodePoint }

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ const {
 } = require('./constants')
 const { ValidationError } = require('./errors')
 const { log, logOutput } = require('./utils')
+const { parseCodePoint } = require('./codepoint')
 const fsAsync = {
   exists    : promisify(fs.exists),
   stat      : promisify(fs.stat),
@@ -157,7 +158,7 @@ async function getCodepointsMap(filepath) {
   }
 
   for (let propName in codepointsMap) {
-    codepointsMap[propName] = Number.parseInt(codepointsMap[propName])
+    codepointsMap[propName] = parseCodePoint(codepointsMap[propName], propName)
   }
 
   return codepointsMap


### PR DESCRIPTION
Improve code point parsing to support unicode literals as value

Also throws a validation error when the codepoint could not be parsed

See issues #54 #56